### PR TITLE
Allow invoking multiple functions

### DIFF
--- a/bin/primea
+++ b/bin/primea
@@ -29,13 +29,16 @@ async function main () {
     const wasm = fs.readFileSync(argv.create)
     const {module} = hypervisor.createActor(WasmContainer.typeId, wasm)
     if (argv.run) {
-      const funcRef = module.getFuncRef(argv.run)
-      funcRef.gas = argv.gas || 20000
-      const message = new Message({
-        funcRef,
-        funcArguments: [new FunctionRef({actorID: egress.id, params: ['data']})]
-      }).on('execution:error', e => console.error(e))
-      hypervisor.send(message)
+      let xs = argv.run.split(",");
+      xs.map((f) => {
+          const funcRef = module.getFuncRef(f)
+          funcRef.gas = argv.gas || 20000
+          const message = new Message({
+            funcRef,
+            funcArguments: [new FunctionRef({actorID: egress.id, params: ['data']})]
+          }).on('execution:error', e => console.error(e))
+          hypervisor.send(message)
+      });
     }
   }
   const sr = await hypervisor.createStateRoot()


### PR DESCRIPTION
A simple way to test more complex behaviors.

Example:
```
primea --create tests.wasm --run state_init,state_modify_1,state_modify_2,state_output
```