### PR TITLE
Allow passing egress as a special parameter

### DIFF
--- a/bin/primea
+++ b/bin/primea
@@ -26,6 +26,7 @@ const argv = require('yargs')
   .describe('r', 'Initial state root')
   .example('$0 -c test.wasm -r ed418f9ba309cb65e34a16ed74253fc813a78412', 'create module test with initial state root')
   .example('$0 -c test.wasm -f main --main 1,2 -a', 'create module, invoke main(1, 2), and get state')
+  .example('$0 -c test.wasm -f main --main egress', 'create module, invoke main(egress) where egress is a built-in funcref for printing to stdout')
   .argv
 
 egress.on('message', msg => {
@@ -98,6 +99,11 @@ async function main () {
         if (params.length != funcArguments.length) {
           console.error('Invalid arguments, want:', params, 'got:', funcArguments)
           return
+        }
+
+        let index = funcArguments.indexOf('egress')
+        if (index !== -1) {
+            funcArguments[index] = new FunctionRef({actorID: egress.id, params: ['data']})
         }
 
         console.log('Invoke', funcRef.identifier[1], funcArguments)

--- a/bin/primea
+++ b/bin/primea
@@ -22,6 +22,7 @@ const argv = require('yargs')
   .alias('a', 'actor')
   .describe('a', 'Get state of an actor')
   .alias('r', 'root')
+  .option('gas', { default: 100000 })
   .describe('r', 'Initial state root')
   .example('$0 -c test.wasm -r ed418f9ba309cb65e34a16ed74253fc813a78412', 'create module test with initial state root')
   .example('$0 -c test.wasm -f main --main 1,2 -a', 'create module, invoke main(1, 2), and get state')
@@ -70,7 +71,7 @@ async function main () {
       funcs.forEach(f => {
         const params = module.exports[f]
         const funcRef = module.getFuncRef(f)
-        funcRef.gas = argv.gas || 100000
+        funcRef.gas = argv.gas
 
         let funcArguments = []
         if (argv[f]) {

--- a/bin/primea
+++ b/bin/primea
@@ -23,6 +23,7 @@ const argv = require('yargs')
   .describe('a', 'Get state of an actor')
   .alias('r', 'root')
   .option('gas', { default: 100000 })
+  .option('quiet', { default: false })
   .describe('r', 'Initial state root')
   .example('$0 -c test.wasm -r ed418f9ba309cb65e34a16ed74253fc813a78412', 'create module test with initial state root')
   .example('$0 -c test.wasm -f main --main 1,2 -a', 'create module, invoke main(1, 2), and get state')
@@ -119,12 +120,16 @@ async function main () {
   }
 
   const sr = await hypervisor.createStateRoot()
-  console.log('New state root:', sr.toString('hex'))
+  if (!argv.quiet) {
+    console.log('New state root:', sr.toString('hex'))
+  }
 
   let actorId
   if (argv.create && !!module) {
     actorId = module.id.id
-    console.log('Created actor with id', actorId.toString('hex'))
+    if (!argv.quiet) {
+      console.log('Created actor with id', actorId.toString('hex'))
+    }
   }
   if (argv.actor) {
     if (typeof argv.actor == 'string') {


### PR DESCRIPTION
Also, added `gas` to CLI help and added `--quiet` flag.

I'd like to save test output and state root and actor id keep changing. It is useful to filter them out from the output.